### PR TITLE
Spellcheck: fix typos / extend allowlist

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,4 +1,6 @@
 [default.extend-words]
+# Portuguese for "constructor" in Portuguese-language source comments
+Construtor = "Construtor"
 # Julia-specific functions
 indexin = "indexin"
 findfirst = "findfirst"

--- a/src/Separation/Flash.jl
+++ b/src/Separation/Flash.jl
@@ -59,7 +59,7 @@
         Nᵍ(t), [description = "Total molar holdup in the gas phase (mol)", guess = 10.0]
 
         T(t), [description = "Drum temperature (K)"]
-        P(t), [description = "Drum pressue (Pa)", guess = 1.2 * 101325.0]
+        P(t), [description = "Drum pressure (Pa)", guess = 1.2 * 101325.0]
         U(t), [description = "Total internal energy holdup in the tank (L + G) (J)"]
         V(t), [description = "Total volume in the tank (L + G) (m³)"]
 

--- a/src/Sources/MaterialSource.jl
+++ b/src/Sources/MaterialSource.jl
@@ -65,7 +65,7 @@
         #Out stuff
         Out.P ~ P
         Out.T ~ T
-        Out.F ~ Fₜ # F is negative as it is leaving the pbject
+        Out.F ~ Fₜ # F is negative as it is leaving the object
         Out.H ~ Hⱼ[1]
         scalarize(Out.z₁ .~ zⱼᵢ[1, :])...
         scalarize(Out.z₂ .~ zⱼᵢ[2, :])...

--- a/test/Reactor_tests/CSTR_test.jl
+++ b/test/Reactor_tests/CSTR_test.jl
@@ -5,7 +5,7 @@ using ProcessSimulator: matcon
 
 # Test for CSTR
 
-#---------- Source objct
+#---------- Source object
 substances = ["water", "methanol", "propyleneglycol", "methyloxirane"]
 idealmodel = ReidIdeal(substances; userlocations = read_reidcp(substances))
 PCSAFT_model = PCPSAFT(substances, idealmodel = idealmodel)


### PR DESCRIPTION
Fixes the failing **Spell Check** (`crate-ci/typos@v1.47.0`) CI.

Reproduced locally with `typos` 1.47.0. Findings and dispositions:

Real prose/comment typos fixed:
- `objct` -> `object` (`test/Reactor_tests/CSTR_test.jl` comment)
- `pressue` -> `pressure` (`src/Separation/Flash.jl` description string)
- `pbject` -> `object` (`src/Sources/MaterialSource.jl` comment)

False positive allowlisted in `.typos.toml`:
- `Construtor` — correct **Portuguese** spelling of "constructor" in a Portuguese-language source comment (`src/Reactors/ReactionManager/KineticReaction.jl`: `# Construtor para aceitar palavras-chave`). Not anglicized so the comment stays valid Portuguese.

`typos` now exits 0 with zero findings.

Ignore until reviewed by @ChrisRackauckas.