### PR TITLE
Runic-format test/qa/qa.jl (fix Format Check on main)

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,7 @@
 using ProcessSimulator, Aqua, JET
 using SciMLTesting
 
-run_qa(ProcessSimulator; Aqua = Aqua, JET = JET, jet = true,
-    jet_kwargs = (; target_defined_modules = true))
+run_qa(
+    ProcessSimulator; Aqua = Aqua, JET = JET, jet = true,
+    jet_kwargs = (; target_defined_modules = true)
+)


### PR DESCRIPTION
## What

Fixes the failing **Runic / Runic Format Check** on `main`.

`test/qa/qa.jl` (added in #49, the SciMLTesting v1.2 conversion) was committed without Runic formatting, so the centralized `runic.yml` check fails on `main`. This reformats the multi-line `run_qa(...)` call to satisfy Runic 1.7.0.

## Diff

```diff
-run_qa(ProcessSimulator; Aqua = Aqua, JET = JET, jet = true,
-    jet_kwargs = (; target_defined_modules = true))
+run_qa(
+    ProcessSimulator; Aqua = Aqua, JET = JET, jet = true,
+    jet_kwargs = (; target_defined_modules = true)
+)
```

No behavior change.

## Local verification

Ran Runic 1.7.0 on Julia 1.10 over every tracked `.jl` file in the repo:

- Before: `test/qa/qa.jl` was the only non-conformant file.
- After: `ALL CLEAN: every tracked .jl file is Runic-conformant`.

## Scope note

This PR fixes **only** the format check. The other red checks on `main` are separate, real issues and are **not** addressed here:

- **QA (JET)** — JET reports a genuine code defect: `local variable ΔHᵣ may be undefined` in `ProcessSimulator.var"#89#90"`.
- **Core (julia 1/lts/pre)** — `test/simple_cstr.jl:91-92` fails numerically (`Tmax` evaluates to `297.0` vs expected `356.149`), a real regression.
- **Downgrade** — `UndefVarError: AbstractNonlinearTerminationMode not defined` while precompiling `DifferentialEquations`/`SteadyStateDiffEq` at downgrade floors (dependency-floor breakage).

Please ignore until reviewed by @ChrisRackauckas.
