### PR TITLE
Fix master CI: JET undefined-var, CSTR + steady-state init, downgrade compat floors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
 DifferentialEquations = "7.16"
-ModelingToolkit = "9.60"
+ModelingToolkit = "9.65"
 SafeTestsets = "0.1"
 SciMLTesting = "1"
 Test = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,8 @@ version = "1.0.0"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
-DifferentialEquations = "7"
-ModelingToolkit = "9"
+DifferentialEquations = "7.16"
+ModelingToolkit = "9.60"
 SafeTestsets = "0.1"
 SciMLTesting = "1"
 Test = "1"

--- a/src/base/base_components.jl
+++ b/src/base/base_components.jl
@@ -123,13 +123,11 @@ end
         ΔE(t), [description = "added/removed heat or work"]          #, unit=u"J/s"]
         V(t), [description = "volume", bounds = (0, Inf)]             #, unit=u"m^3"]
     end
-    reactive ?
-        append!(
-            vars, @variables begin
-                ΔnR(t)[1:ms.N_c], [description = "molar holdup change by reaction"]     #, unit=u"mol"])
-                ΔHᵣ(t), [description = "enthalpy of reaction"]                #, unit=u"J/s"]
-            end
-        ) : nothing
+    reaction_vars = @variables begin
+        ΔnR(t)[1:ms.N_c], [description = "molar holdup change by reaction"]     #, unit=u"mol"])
+        ΔHᵣ(t), [description = "enthalpy of reaction"]                #, unit=u"J/s"]
+    end
+    reactive ? append!(vars, reaction_vars) : nothing
 
     eqs = [
         ΔH ~ sum([c.h * c.n for c in mcons]),

--- a/test/simple_cstr.jl
+++ b/test/simple_cstr.jl
@@ -77,19 +77,32 @@ u0 = [
     cstr.cv.nᵢ[1, 4] => 0.0,
     inlet.m => m0_inlet,
     cstr.cv.T => 297.0,
+]
+
+# `cstr.cv.c2` (outlet) and `outlet.m` are fixed by the algebraic flow balances,
+# not independent initial states. Pinning them in `u0` over-determines MTK's
+# initialization system (4 algebraic residuals, 0 free unknowns -> InitialFailure).
+# They must be supplied as initialization guesses instead.
+guesses = [
     cstr.cv.c2.n => 0.0,
     outlet.m => 0.0,
 ]
 
 flowsheet, idx = structural_simplify(flowsheet_, (first.(inp), []))
 
-prob = ODEProblem(flowsheet, u0, (0, 2) .* 3600.0, vcat(inp)) #; guesses = [outlet.m => -m0_inlet])
+prob = ODEProblem(flowsheet, u0, (0, 2) .* 3600.0, vcat(inp); guesses = guesses)
 sol = solve(prob, QNDF(), abstol = 1.0e-6, reltol = 1.0e-6)
 
 (Tmax, iTmax) = findmax(sol[cstr.cv.T])
 
 @test Tmax ≈ 356.149 atol = 1.0e-3
-@test sol.t[iTmax] ≈ 2823.24 atol = 1.0e-2
+# The peak temperature sits on a flat plateau: across the ~4 s solver steps
+# bracketing the maximum, T varies by < 0.002 K. The `findmax` argmax therefore
+# lands on whichever sampled step is highest, and that step shifts by one solver
+# step (~0.02 s) with the Julia/solver version (1.10: 2823.2427 s, 1.12:
+# 2823.2227 s) even though Tmax itself is identical to 6 figures. atol = 0.1
+# (relative 3.5e-5) still pins the peak time tightly while tolerating that shift.
+@test sol.t[iTmax] ≈ 2823.24 atol = 0.1
 
 if isinteractive()
     # Plots

--- a/test/simple_steady_state.jl
+++ b/test/simple_steady_state.jl
@@ -45,7 +45,12 @@ u0_comp = [
     comp.ηᴱ => 0.8,
 ]
 
-prob_comp = SteadyStateProblem(compressor, inp_comp, u0_comp)
+# The compressor is purely algebraic (no differential states after simplification),
+# so its steady state is the root of the algebraic equations. Building a
+# `SteadyStateProblem` here makes MTK assemble an over-determined initialization
+# system that fails (`InitialFailure`) and returns the untouched guess; solve the
+# algebraic steady state directly as a `NonlinearProblem` instead.
+prob_comp = NonlinearProblem(compressor, u0_comp, inp_comp)
 sol_comp = solve(prob_comp)
 
 @test sol_comp[comp.W] ≈ 2.3933999e6 rtol = 1.0e-5
@@ -104,7 +109,9 @@ flowsheet, idx = structural_simplify(flowsheet_, (first.(inp), out))
 
 u0 = [u => 1.0 for u in unknowns(flowsheet)]
 
-prob = SteadyStateProblem(flowsheet, inp, u0)
+# As with the single compressor above, the flowsheet is fully algebraic, so its
+# steady state is solved directly as a `NonlinearProblem`.
+prob = NonlinearProblem(flowsheet, u0, inp)
 sol = solve(prob)
 
 ε_KM = abs(sol[heat_44⁺.Q]) / abs(sol[turb_34.W] + sol[comp_12.W])


### PR DESCRIPTION
## Summary

Fixes the three independent failures on `main` CI (HEAD `7cad441`):

1. **QA / JET** — `local variable ΔHᵣ may be undefined`. In `TPControlVolume` (`src/base/base_components.jl`), the reaction variables `ΔnR`/`ΔHᵣ` were created with `@variables` *inside* a `reactive ? append!(...) : nothing` ternary, so they were never bound when `reactive == false`, while the equation list references them (guarded by `reactive ? ... : 0.0`). Moving the `@variables` block out of the ternary makes them always defined; they are only appended to the system's variable list when `reactive`. `JET.report_package` now reports **0 errors** and `run_qa` passes **12/12** on Julia 1.12.

2. **Core tests** (`test/simple_cstr.jl`, all Julia versions) — `Tmax = 297.0` instead of `356.149` (no reaction). The test pinned `cstr.cv.c2.n` and `outlet.m` in `u0`; these are fixed by the algebraic flow balances, so pinning them over-determines MTK initialization (4 residuals, 0 free unknowns) and the least-squares fallback yields a degenerate steady state. Supplied as initialization `guesses` instead. The peak-*time* assertion is relaxed `1e-2 → 0.1` because the maximum sits on a flat plateau (<0.002 K across the bracketing steps), so the discrete argmax time shifts by one solver step (~0.02 s) across Julia versions while `Tmax` is identical to 6 figures; the physically meaningful `Tmax` assertion stays tight at `1e-3`. Verified `Pass 2/2` on Julia 1.10 and 1.12.

3. **Downgrade** (Julia 1.10) — `UndefVarError: AbstractNonlinearTerminationMode not defined`. The floors `ModelingToolkit = "9"` / `DifferentialEquations = "7"` let downgrade-compat resolve an inconsistent SciML stack (NonlinearSolve 3.14 + DiffEqBase 6.174 + SteadyStateDiffEq 2.0; later, BoundaryValueDiffEqFIRK 1.6 vs RecursiveArrayTools 3.50). Raised to `ModelingToolkit = "9.60"` (pins NonlinearSolve 4.x) and `DifferentialEquations = "7.16"` (pins a modern BVP/SteadyState stack). Raising lower bounds only narrows resolution. Verified the downgraded resolution precompiles and `simple_cstr.jl` passes **2/2** on Julia 1.10.

## Local verification

- Julia 1.12: `JET.report_package` → 0 reports; `run_qa` → `Quality Assurance | 12 12`; `simple_cstr.jl` → `Pass 2/2`.
- Julia 1.10: downgrade-compat resolution (via `julia-downgrade-compat`'s `downgrade.jl`) precompiles cleanly with the new floors; `simple_cstr.jl` → `Pass 2/2`.

Files Runic-formatted.

---

## Core `simple_steady_state.jl` (all Julia versions) — algebraic steady state

The remaining Core failure (4/4 fails in `test/simple_steady_state.jl`) had the
same root cause family as the CSTR fix: an over-determined MTK *initialization*
system. The single compressor and the full Brayton-cycle flowsheet are **purely
algebraic** after `structural_simplify` (no differential states), so the
`SteadyStateProblem` MTK builds for them assembles an over-determined
initialization system (e.g. "6 equations for 2 unknowns") whose least-squares
fallback returns `InitialFailure`. `solve` then hands back the untouched initial
guess (`u0 = 1.0`), producing the degenerate values the asserts caught:
`comp.W = -1.56e6` (vs 2.3933999e6), `s2.T = s4.T = 1.0` (vs 755.58 / 99.89),
`ε_KM = 0.02` (vs 0.504).

Fix: build these algebraic steady states directly as `NonlinearProblem`s (the
correct problem type for a derivative-free steady state). No assertion value or
tolerance was changed.

Verified locally on Julia 1.12.6 with the exact CI-resolved stack (MTK 9.84.0,
DifferentialEquations 7.17.0): `simple_steady_state.jl` passes **4/4** via
SafeTestsets (`comp.W = 2.393399947834445e6`, `s2.T = 755.58`, `s4.T = 99.89`,
`ε_KM = 0.504`; all `solve` calls return `retcode = Success`).


### Downgrade follow-up — MTK floor 9.60 -> 9.65

The `NonlinearProblem` switch above relies on MTK's
`NonlinearProblem(::ODESystem, u0, p)` symbolic-problem dispatch. On the old
downgrade floor `ModelingToolkit = 9.60` that dispatch does not exist:
`NonlinearProblem(sys, ...)` falls through to the bare SciMLBase constructor and
errors with "No methods were found for the model function passed to the equation
solver". Bisected on Julia 1.10: MTK 9.60 errors, MTK 9.65 / 9.70 work. Raised
the floor to `ModelingToolkit = 9.65` (raising a lower bound only narrows
resolution).

Verified locally on Julia 1.10 with the downgrade-pinned stack (MTK 9.65.0,
DifferentialEquations 7.17.0): the env resolves + precompiles cleanly and
`simple_steady_state.jl` passes 4/4 via SafeTestsets.

Please ignore until reviewed by @ChrisRackauckas