### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 DifferentialEquations = "7.16"
 ModelingToolkit = "9.65, 11.28"
 SafeTestsets = "0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"
 

--- a/src/ProcessSimulator.jl
+++ b/src/ProcessSimulator.jl
@@ -1,8 +1,10 @@
 module ProcessSimulator
 
-using ModelingToolkit
+using ModelingToolkit: ModelingToolkit, @component, @connector, @named,
+    @parameters, @variables, Equation, Flow, ODESystem
 using ModelingToolkit: t_nounits as t, D_nounits as D
-using ModelingToolkit: scalarize, equations, get_unknowns
+# scalarize is owned by SymbolicUtils and re-exported (non-public) via ModelingToolkit
+using ModelingToolkit: scalarize
 
 # Base
 include("base/materials.jl")

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ ProcessSimulator = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,7 +1,14 @@
-using ProcessSimulator, Aqua, JET
-using SciMLTesting
+using SciMLTesting, ProcessSimulator, Test
+using JET
 
 run_qa(
-    ProcessSimulator; Aqua = Aqua, JET = JET, jet = true,
-    jet_kwargs = (; target_defined_modules = true)
+    ProcessSimulator;
+    explicit_imports = true,
+    jet_kwargs = (; target_defined_modules = true),
+    ei_kwargs = (;
+        # scalarize is owned by SymbolicUtils and re-exported (non-public) via
+        # ModelingToolkit, which is where ProcessSimulator explicitly imports it.
+        all_explicit_imports_via_owners = (; ignore = (:scalarize,)),
+        all_explicit_imports_are_public = (; ignore = (:scalarize,)),
+    ),
 )


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Brings this repo's QA onto the SciMLTesting 1.6 `run_qa` form and enables ExplicitImports.

## qa.jl (v1.6 form)
- Aqua and ExplicitImports now come from SciMLTesting's own deps (no longer threaded in via `Aqua = Aqua`); JET stays opt-in via `using JET`.
- `explicit_imports = true` turns on the six ExplicitImports checks.
- No `aqua_broken`/`jet_broken`/`ei_broken`: the pre-conversion QA had zero `@test_broken` markers and all checks (including the new EI ones) pass after the source fixes below.

## ExplicitImports findings (6 checks)
Resolved in `src/ProcessSimulator.jl`, preference FIX > IGNORE > BROKEN:
- **no_stale_explicit_imports** (FIXED): dropped `equations` and `get_unknowns` — unused (only appeared on the import line / in comments).
- **no_implicit_imports** (FIXED): replaced the bare `using ModelingToolkit` with explicit imports of the names actually used — `ModelingToolkit, @component, @connector, @named, @parameters, @variables, Equation, Flow, ODESystem` (exactly ExplicitImports' suggested line).
- **all_explicit_imports_via_owners** + **all_explicit_imports_are_public** (IGNORED, documented): `scalarize` is owned by `SymbolicUtils` and re-exported (non-public) through `ModelingToolkit`, which is where it is imported. Ignored for these two checks via `ei_kwargs`. Goes away if/when ModelingToolkit/SymbolicUtils mark it public/owned.
- **all_qualified_accesses_via_owners** + **all_qualified_accesses_are_public** (PASS, no ignore needed).

Net: 0 hard FAIL.

## Deps
- SciMLTesting compat floor bumped to `"1.6"` (root + `test/qa/Project.toml`).
- ExplicitImports is **not** added as a dep (transitive via SciMLTesting).
- Aqua kept (the `ambiguities` sub-check runs Aqua in a child process and needs it a direct dep); JET kept (JET runs).

## Verification
Ran the QA group locally on Julia 1.10 against **released SciMLTesting 1.6.0** (Pkg-resolved, not dev-from-branch):

```
Resolved SciMLTesting: 1.6.0
Test Summary: | Pass  Total
QA/qa.jl      |   18     18
```

18/18: Aqua (11) + JET (1) + ExplicitImports (6), 0 fail/error/broken. The 6 EI checks were also run individually under named testsets to confirm each one runs and passes (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)