### PR TITLE
Update QA to SciMLTesting 2.1 docs checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 DifferentialEquations = "7.16"
 ModelingToolkit = "9.65, 11.28"
 SafeTestsets = "0.1"
-SciMLTesting = "1.6"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,13 +6,10 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-ProcessSimulator = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.6"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -5,6 +5,7 @@ run_qa(
     ProcessSimulator;
     explicit_imports = true,
     jet_kwargs = (; target_defined_modules = true),
+    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         # scalarize is owned by SymbolicUtils and re-exported (non-public) via
         # ModelingToolkit, which is where ProcessSimulator explicitly imports it.


### PR DESCRIPTION
Ignore this draft PR until reviewed by @ChrisRackauckas.

## Summary
- Update SciMLTesting compat to 2.1.
- Remove the repo-local QA [sources] path entry.
- Use SciMLTesting public API docs QA with rendered docs checking.

## Validation
- Runic --check on changed Julia files passed.
- TOML.parsefile over assigned Project.toml files passed.
- GROUP=QA julia +1.11 --project=. -e "using Pkg; Pkg.test()" passed: QA/qa.jl 20 passed, 20 total.