### PR TITLE
Raise Symbolics floor to 6.58

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ ModelingToolkit = "9.65, 11.28"
 SafeTestsets = "0.1"
 SciMLPublic = "1"
 SciMLTesting = "2.4"
-Symbolics = "6.58, 7"
+Symbolics = "7"
 Test = "1"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ ModelingToolkit = "9.65, 11.28"
 SafeTestsets = "0.1"
 SciMLPublic = "1"
 SciMLTesting = "2.4"
-Symbolics = "5, 6, 7"
+Symbolics = "6.58, 7"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` lower-bound bump:

- `Symbolics = "5, 6, 7"` → `"6.58, 7"`

No library code, tests, or package version were changed.

## Why

ProcessSimulator requires `ModelingToolkit = "9.65, 11.28"`. Symbolics 5.0.0 and 6.0.0 cannot resolve against that ModelingToolkit window (5.0.0 only co-installs with ModelingToolkit ≤ 5.9.1; 6.0.0 only with ModelingToolkit ≤ 5.9.1 or 9.33.x). Symbolics 6.58.0 is the first 6.x pin verified here to load with in-tree ProcessSimulator.

The 7.x range is unchanged. Older 7.x pins (7.0.0 / 7.6.0 / 7.12.0 / 7.18.1) fail on PreallocationTools, but that is a 7.x-internal floor, not a reason to drop 7.

## Verification

Julia 1.10.11, `Pkg.develop` of this checkout, then `Pkg.add(name="Symbolics", version=...)`:

| Symbolics | Result |
|---|---|
| 5.0.0 (old 5.x floor) | unsatisfiable vs ModelingToolkit 9.65+/11.28+ |
| 6.0.0 (old 6.x floor) | unsatisfiable vs ModelingToolkit 9.65+/11.28+ |
| 6.58.0 (new 6.x floor) | `RESOLVE_OK` / `USING_OK ProcessSimulator 1.1.0` / `DEP_OK Symbolics 6.58.0` |
| 7.0.0 / 7.6.0 / 7.12.0 / 7.18.1 | unsatisfiable (PreallocationTools); 7 range left as-is |

Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
