### PR TITLE
Drop older SciML major versions from compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,8 @@ SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-DifferentialEquations = "7.16"
-ModelingToolkit = "9.65, 11.28"
+DifferentialEquations = "8"
+ModelingToolkit = "11.28"
 SafeTestsets = "0.1"
 SciMLPublic = "1"
 SciMLTesting = "2.4"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` edits that **drop older major versions of SciML packages**. For each SciML dependency, only the current major remains (existing lower bound on that major is kept). No code, tests, or package version were changed.

- `Project.toml` [extras] `DifferentialEquations`: `7.16` → `8` (drop 7.16; current SciML major is 8)
- `Project.toml` [deps] `ModelingToolkit`: `9.65, 11.28` → `11.28` (drop 9.65; current SciML major is 11)

## Why

Supporting multiple SciML majors keeps untested resolver windows. The current major is the one in the General registry; older majors are dropped even when that current major is recent.

## Verification

Current majors come from JuliaRegistries/General `Versions.toml`. Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
