### PR TITLE
Add PrecompileTools workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "1.1.0"
 
 [deps]
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 DifferentialEquations = "8"
 ModelingToolkit = "11.28"
+PrecompileTools = "1"
 SafeTestsets = "0.1"
 SciMLPublic = "1"
 SciMLTesting = "2.4"

--- a/src/ProcessSimulator.jl
+++ b/src/ProcessSimulator.jl
@@ -18,4 +18,6 @@ include("fluid_handling/heat_exchangers.jl")
 # Reactors
 include("reactors/CSTR.jl")
 
+include("precompile.jl")
+
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,31 @@
+using PrecompileTools: @compile_workload, @setup_workload
+
+@setup_workload begin
+    reaction_rate = (p, T, xᵢ) -> 0.1 * xᵢ[1]
+    reaction_enthalpy = T -> -5.0e4
+    molar_density = (p, T, xᵢ; kwargs...) -> p / (8.314 * T)
+    enthalpy = (ϱ, T, xᵢ) -> 20.0 * T
+    internal_energy = (ϱ, T, xᵢ) -> 12.0 * T
+    entropy = (ϱ, T, xᵢ) -> log(T)
+
+    @compile_workload begin
+        reaction = Reaction(
+            ν = [-1.0, 1.0], r = reaction_rate, Δhᵣ = reaction_enthalpy
+        )
+        material = MaterialSource(
+            ["reactant", "product"];
+            Mw = [0.01, 0.02],
+            molar_density,
+            VT_enthalpy = enthalpy,
+            VT_internal_energy = internal_energy,
+            VT_entropy = entropy,
+            reactions = [reaction],
+        )
+
+        Port(material; name = :inlet)
+        MaterialStream(material; name = :stream)
+        SimpleAdiabaticCompressor(material; name = :compressor)
+        SimpleIsobaricHeatExchanger(material; name = :exchanger)
+        CSTR(material; name = :reactor, flowtype = "const. volume")
+    end
+end


### PR DESCRIPTION
## Summary
Adds a PrecompileTools workload covering representative public APIs so the package common execution path is compiled during precompilation.

## Verification
The branch was validated locally with package load/precompile, a focused workload smoke test, and repository checks where available. Runic, typos, and git diff --check were checked for the change.

## Known limitations
Core and QA retain pre-existing failures reproduced on clean origin/main (partial-array input and scalarize ownership).

This draft should be ignored until reviewed by @ChrisRackauckas.