### PR TITLE
Fix simple_cstr test for MTK 11 array input requirements

### DIFF
--- a/test/simple_cstr.jl
+++ b/test/simple_cstr.jl
@@ -59,11 +59,15 @@ eqs = [
 
 pars = []
 
+x_frac = F ./ sum(F)
 inp = [
     inlet.T => 297.0,
     inlet.p => 1.0e5,
     inlet.n => sum(F),
-    inlet.xᵢ => F ./ sum(F),
+    inlet.xᵢ[1] => x_frac[1],
+    inlet.xᵢ[2] => x_frac[2],
+    inlet.xᵢ[3] => x_frac[3],
+    inlet.xᵢ[4] => x_frac[4],
     outlet.p => 1.0e5,
 ]
 

--- a/test/simple_cstr.jl
+++ b/test/simple_cstr.jl
@@ -86,7 +86,7 @@ guesses = [
     outlet.m => 0.0,
 ]
 
-flowsheet, idx = structural_simplify(flowsheet_, (first.(inp), []))
+flowsheet = structural_simplify(flowsheet_, (first.(inp), []))
 
 prob = ODEProblem(flowsheet, u0, (0, 2) .* 3600.0, vcat(inp); guesses = guesses)
 sol = solve(prob, QNDF(), abstol = 1.0e-6, reltol = 1.0e-6)

--- a/test/simple_cstr.jl
+++ b/test/simple_cstr.jl
@@ -63,9 +63,7 @@ inp = [
     inlet.T => 297.0,
     inlet.p => 1.0e5,
     inlet.n => sum(F),
-    inlet.xᵢ[1] => F[1] / sum(F),
-    inlet.xᵢ[2] => F[2] / sum(F),
-    inlet.xᵢ[3] => F[3] / sum(F),
+    inlet.xᵢ => F ./ sum(F),
     outlet.p => 1.0e5,
 ]
 

--- a/test/simple_steady_state.jl
+++ b/test/simple_steady_state.jl
@@ -38,7 +38,7 @@ inp_comp = [
     outlet.p => 1.0e6,
 ]
 out_comp = [comp.W]
-compressor, idx = structural_simplify(compressor_, (first.(inp_comp), out_comp))
+compressor = structural_simplify(compressor_, (first.(inp_comp), out_comp))
 
 u0_comp = [
     (u => 1.0 for u in unknowns(compressor))...,
@@ -105,7 +105,7 @@ out = [
     turb_34.W,
 ]
 
-flowsheet, idx = structural_simplify(flowsheet_, (first.(inp), out))
+flowsheet = structural_simplify(flowsheet_, (first.(inp), out))
 
 u0 = [u => 1.0 for u in unknowns(flowsheet)]
 


### PR DESCRIPTION
## Summary
- Fixes Core test failure in `test/simple_cstr.jl` caused by ModelingToolkit 11 rejecting partial array variable inputs.
- Replaces per-element `inlet.xᵢ[1:3]` input assignments with a single full-vector `inlet.xᵢ => F ./ sum(F)`.

## Root cause
MTK 11 requires that array variables be specified as inputs in their entirety; assigning only `inlet.xᵢ[1]`, `inlet.xᵢ[2]`, and `inlet.xᵢ[3]` triggers `ArgumentError: Part of an array variable cannot be made an input`.

## Test plan
- [x] Verified the fix matches the CI error and MTK 11 input API
- [ ] CI Core group (`simple_cstr.jl`) passes on Julia lts, 1, and pre


Made with [Cursor](https://cursor.com)