### PR TITLE
Format for Runic v1.10

### DIFF
--- a/src/reactors/CSTR.jl
+++ b/src/reactors/CSTR.jl
@@ -59,27 +59,27 @@ julia> nameof(reactor)
         cv.c2.T ~ cv.T,     # Change of moles by reaction
         [
             cv.ΔnR[i] ~ reac.r(
-                    cv.p,
-                    cv.T,
-                    collect(
-                        cv.xᵢ[
-                            1, :,
-                        ]
-                    )
-                ) * reac.ν[i] * cv.n
+                cv.p,
+                cv.T,
+                collect(
+                    cv.xᵢ[
+                        1, :,
+                    ]
+                )
+            ) * reac.ν[i] * cv.n
                 for i in 1:ms.N_c,
                 reac in ms.reaction[i_reacts]
         ]...,     # Enthalpy of reaction
         [
             cv.ΔHᵣ ~ reac.r(
-                    cv.p,
-                    cv.T,
-                    collect(
-                        cv.xᵢ[
-                            1, :,
-                        ]
-                    )
-                ) * reac.Δhᵣ(cv.T) * cv.n
+                cv.p,
+                cv.T,
+                collect(
+                    cv.xᵢ[
+                        1, :,
+                    ]
+                )
+            ) * reac.Δhᵣ(cv.T) * cv.n
                 for reac in ms.reaction[i_reacts]
         ]...,
     ]

--- a/src/separation/distillation.jl
+++ b/src/separation/distillation.jl
@@ -2,13 +2,13 @@
     # Subsystems
     stages = [
         SimpleStage(
-                ms; name = "stage$i", add_flows = sum(
-                    i .==
+            ms; name = "stage$i", add_flows = sum(
+                i .==
                     [
-                        1, N_stages,
-                    ]
-                ) + sum(i .== i_feeds)
-            ) for i in 1:N_stages
+                    1, N_stages,
+                ]
+            ) + sum(i .== i_feeds)
+        ) for i in 1:N_stages
     ]
 
     # Connect stages

--- a/test/simple_cstr.jl
+++ b/test/simple_cstr.jl
@@ -114,9 +114,9 @@ if isinteractive()
     plot!(ps[1], sol.t / 3600, sol[cstr.cv.T], label = "T", ylabel = "T / K")
     [
         plot!(
-                ps[2], sol.t / 3600, sol[cstr.cv.xᵢ[1, i]];
-                label = matsource.components[i], ylabel = "xᵢ / mol/mol"
-            ) for i in 1:4
+            ps[2], sol.t / 3600, sol[cstr.cv.xᵢ[1, i]];
+            label = matsource.components[i], ylabel = "xᵢ / mol/mol"
+        ) for i in 1:4
     ]
     plot(ps...; layout = (1, 2), size = (800, 400))
 end


### PR DESCRIPTION
## What changed and why

Reformats the files affected by Runic v1.10's updated formatting rules. This is a mechanical formatting-only change so the repository's Runic check passes with the current release.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

The unmodified base commit `60e9d24` exits 1 under Runic v1.10.0. With this change applied:

```text
~/.juliaup/bin/julia +release --project=@runic -m Runic --check .
exit 0

git diff --check
exit 0

typos (changed files)
exit 0

GROUP=QA julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
QA/qa.jl | 20 passed / 20 total
Testing ProcessSimulator tests passed
```

The Core group currently fails on both the formatted branch and the unmodified base at the existing scalar-bounds assertion in `simple_cstr.jl`. That independent behavior failure is tracked with exact reproduction and dependency-boundary details in https://github.com/SciML/ProcessSimulator.jl/issues/60.

With the separate local ProcessSimulator correction stacked on the ModelingToolkit fixes in https://github.com/SciML/ModelingToolkit.jl/pull/5050 and https://github.com/SciML/ModelingToolkit.jl/pull/5051, the complete Core group passes:

```text
Core/public_api_tests.jl | 8 passed / 8 total
Core/simple_cstr.jl | 3 passed / 3 total
Core/simple_steady_state.jl | 4 passed / 4 total
```

Those behavior changes are intentionally not mixed into this mechanical formatting PR.

## Not verified

The standalone formatter branch cannot complete Core until the independent base failure above is fixed. No GPU-specific or downstream-package jobs were run locally. Documentation was not built because this changes neither documentation, docstrings, nor public API.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
